### PR TITLE
Add a function for interpolating environment variables

### DIFF
--- a/docs/configuration_syntax.md
+++ b/docs/configuration_syntax.md
@@ -93,7 +93,7 @@ Here is a contextualized example: [docs/examples/workspace_configuration.md](exa
 
 ```hcl
 defaults {
-  
+
   // You can define as many provider blocks as you want
   // Default Vault configuration
   vault {
@@ -104,7 +104,7 @@ defaults {
   s5 {
     ...
   }
-  
+
   // There is no default configuration support for the env provider though
 }
 ```
@@ -295,3 +295,11 @@ env {
 ```
 
 Here is a contextualized example: [docs/examples/provider_env.md](examples/provider_env.md)
+
+## Functions
+
+The following functions are supported in HCL by TFCW:
+
+|**name**|**description**|**parameters**|**example**|
+|---|---|---|---|
+|env()|Fetches value from environment variable|`envvar`|`workspace = "my_app-${env("REGION")}"`|

--- a/go.mod
+++ b/go.mod
@@ -16,4 +16,5 @@ require (
 	github.com/sirupsen/logrus v1.5.0
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli v1.22.3
+	github.com/zclconf/go-cty v1.2.1
 )

--- a/lib/functions/env.go
+++ b/lib/functions/env.go
@@ -1,0 +1,29 @@
+package functions
+
+import (
+	"os"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+)
+
+// EnvFunction constructs a function that looks up an EnvironmentVariable given the
+// variable name
+var EnvFunction = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{
+			Name: "envvar",
+			Type: cty.String,
+		},
+	},
+	Type: function.StaticReturnType(cty.String),
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		envvar := args[0].AsString()
+		return cty.StringVal(os.Getenv(envvar)), nil
+	},
+})
+
+// Env performs a function call to EnvFunction, useful for testing
+func Env(envvar cty.Value) (cty.Value, error) {
+	return EnvFunction.Call([]cty.Value{envvar})
+}

--- a/lib/functions/env_test.go
+++ b/lib/functions/env_test.go
@@ -1,0 +1,32 @@
+package functions
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestFunctionEnv(t *testing.T) {
+	tests := []struct {
+		Variable cty.Value
+		Value    cty.Value
+	}{
+		{
+			cty.StringVal("FOO"),
+			cty.StringVal("BAR"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("env(%#v)", test.Variable.AsString()), func(t *testing.T) {
+			os.Setenv(test.Variable.AsString(), test.Value.AsString())
+
+			got, _ := Env(test.Variable)
+			if !got.RawEquals(test.Value) {
+				t.Errorf("wrong result\ngot:  %#v\nwant: %#v", got, test.Value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/mvisonneau/tfcw/issues/15

Creates the `env()` function that we can use to do simple lookups against env vars within the HCL.

example usage:
```
workspace {
  name = "my_app-${env("REGION")}"
}
```