### PR TITLE
Check for kv-v2 backend response from Vault

### DIFF
--- a/lib/providers/vault/vault.go
+++ b/lib/providers/vault/vault.go
@@ -85,8 +85,17 @@ func (c *Client) GetValues(v *schemas.Vault) (results map[string]string, err err
 			return results, fmt.Errorf("no results/keys returned for secret : %s", *v.Path)
 		}
 
-		for k, v := range secret.Data {
-			results[k] = v.(string)
+		// kv-v2 backend returns a slightly differnet response than others
+		_, hasDataField := secret.Data["data"]
+		_, hasMetaDataField := secret.Data["metadata"]
+		if hasDataField && hasMetaDataField {
+			for k, v := range secret.Data["data"].(map[string]interface{}) {
+				results[k] = v.(string)
+			}
+		} else {
+			for k, v := range secret.Data {
+				results[k] = v.(string)
+			}
 		}
 
 		return


### PR DESCRIPTION
The response from the kv v2 backend differs to that from other backends due to versioning

https://www.vaultproject.io/api/secret/kv/kv-v2.html#sample-response-1
 vs
https://www.vaultproject.io/api-docs/secret/aws/#sample-response
https://www.vaultproject.io/api-docs/secret/kv/kv-v1/#sample-response 

This does a simple check very simple check to decide how to parse the response. There may be a more elegant way to approach this..